### PR TITLE
Updated eip_association example

### DIFF
--- a/website/source/docs/providers/aws/r/eip_association.html.markdown
+++ b/website/source/docs/providers/aws/r/eip_association.html.markdown
@@ -19,7 +19,7 @@ pre-existing or distributed to customers or users and therefore cannot be change
 ```
 resource "aws_eip_association" "eip_assoc" {
   instance_id = "${aws_instance.web.id}"
-  allocation_id = "${aws_eip.example.allocation_id}"
+  allocation_id = "${aws_eip.example.id}"
 }
 
 resource "aws_instance" "web" {


### PR DESCRIPTION
**Reasoning for docs update**: The example is referencing a non-existent variable, `allocation_id`, within the `aws_eip` resource. I believe this should actually be `aws_eip.example.id` instead of `aws_eip.example.allocation_id`. Following the example will result in an error when applying your terraform configuration.

**Relevant Terraform version:** Terraform v0.6.16
